### PR TITLE
Update FetchVariantAnnotationByGenomicLocationPOST to receive correct return value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,9 @@ module github.com/averyniceday/go-gnap
 
 go 1.18
 
+require github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc
+
 require (
-	github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/averyniceday/go-gnap
 go 1.18
 
 require (
-	github.com/averyniceday/go-mpath-proto v0.0.0-20230419152402-ef43b8cf024f // indirect
+	github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/callachennault/go-gnap
+module github.com/averyniceday/go-gnap
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/averyniceday/go-gnap
+module github.com/callachennault/go-gnap
 
 go 1.18
 

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/averyniceday/go-mpath-proto v0.0.0-20230413200706-30f5912119cf h1:PfY
 github.com/averyniceday/go-mpath-proto v0.0.0-20230413200706-30f5912119cf/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
 github.com/averyniceday/go-mpath-proto v0.0.0-20230419152402-ef43b8cf024f h1:93VGr1cD+m9nKO6cBiVkSg28Pg4WYeZ//rEcqggTND8=
 github.com/averyniceday/go-mpath-proto v0.0.0-20230419152402-ef43b8cf024f/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
+github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc h1:nWY3Icla3iML3cx+47CNj9/0CrU1QGW87lR4We/S/MQ=
+github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,3 @@
-github.com/averyniceday/go-mpath-proto v0.0.0-20230329165407-16d6085cee92 h1:kA+AI0qB0zSZc/gqY3y8aIiNImio9AoMpc7KWZuWpbM=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230329165407-16d6085cee92/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230413200414-2fb9af53d5a3 h1:WX6F5LyMIfcVtVG4MXodfqbNPQjohYNNMNZZmMoYHsI=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230413200414-2fb9af53d5a3/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230413200706-30f5912119cf h1:PfY1CSpoP508oXrLLwO3WO8nBZSENOz1modH3DGxbxM=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230413200706-30f5912119cf/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230419152402-ef43b8cf024f h1:93VGr1cD+m9nKO6cBiVkSg28Pg4WYeZ//rEcqggTND8=
-github.com/averyniceday/go-mpath-proto v0.0.0-20230419152402-ef43b8cf024f/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
 github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc h1:nWY3Icla3iML3cx+47CNj9/0CrU1QGW87lR4We/S/MQ=
 github.com/averyniceday/go-mpath-proto v0.0.0-20230428212610-c2d59dc06cdc/go.mod h1:To28yQaSwfSsYEh/IAnIKCQroqrp4lw6A18Y2Ljyxgk=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -13,6 +5,7 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=

--- a/gognap/annotator.go
+++ b/gognap/annotator.go
@@ -3,37 +3,42 @@ package gognap
 import (
 	"context"
 	"fmt"
-	pubgn "github.com/averyniceday/go-mpath-proto/genome-nexus-public-api"
 	"os"
-)
 
+	pubgn "github.com/averyniceday/go-mpath-proto/genome-nexus-public-api"
+)
 
 // TODO add summary statistics
 // Java call: annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, records, "mskcc", true, postIntervalSize, reannotate);
 
-func GetVariantAnnotations(genomicLocations []pubgn.GenomicLocation) []pubgn.VariantAnnotation{
-	options := make(map[string]interface{})
-	options["fields"] = []string{"annotation_summary"}
+func GetVariantAnnotations(genomicLocations []pubgn.GenomicLocation) []pubgn.VariantAnnotation {
+	var token = ""
+	fields := make([]string, 0)
+	fields = append(fields, "annotation_summary")
+	var isoformOverrideSource = ""
 	configuration := pubgn.NewConfiguration()
 	apiClient := pubgn.NewAPIClient(configuration)
-	variantAnnotations, r, err := apiClient.AnnotationControllerApi.FetchVariantAnnotationByGenomicLocationPOST(context.Background(), genomicLocations, options)
-    	if err != nil {
-			fmt.Fprintf(os.Stderr, "Error when calling `AnnotationControllerApi.FetchVariantAnnotationByGenomicLocationGET``: %v\n", err)
-			fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
-		}
+	x := apiClient.AnnotationControllerApi.FetchVariantAnnotationByGenomicLocationPOST(context.Background()).GenomicLocations(genomicLocations)
+	x = x.Fields(fields)
+	x = x.IsoformOverrideSource(isoformOverrideSource)
+	x = x.Token(token)
+	variantAnnotations, r, err := x.Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `AnnotationControllerApi.FetchVariantAnnotationByGenomicLocationGET``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+	}
 	fmt.Println("sigh \n\n\n\n")
 	fmt.Println(r.Request)
 	fmt.Println(r.Header)
 	// https://github.com/averyniceday/go-mpath-proto/blob/16d6085cee926ad85fc29c6c62319ee3697edcf2/genome-nexus-public-api/api_annotation_controller.go#L218
-    	// response from `FetchVariantAnnotationByGenomicLocationPOST`: []VariantAnnotation, *http.Response, error
+	// response from `FetchVariantAnnotationByGenomicLocationPOST`: []VariantAnnotation, *http.Response, error
 	// VariantAnnotation defined here: https://github.com/averyniceday/go-mpath-proto/blob/16d6085cee926ad85fc29c6c62319ee3697edcf2/genome-nexus-internal-api/model_variant_annotation.go#L21
 	for i := 0; i < len(variantAnnotations); i++ {
-		if !variantAnnotations[i].SuccessfullyAnnotated {
+		if !*variantAnnotations[i].SuccessfullyAnnotated {
 			fmt.Println("ERROR: Failed to annotate: ", variantAnnotations[i].Variant)
 		} else {
-			fmt.Println("Success: ", variantAnnotations[i].AnnotationSummary.TranscriptConsequences[0].TranscriptId)
+			fmt.Println("Success: ", *variantAnnotations[i].SuccessfullyAnnotated)
 		}
 	}
 	return variantAnnotations
 }
-


### PR DESCRIPTION
This PR updates the number of return values received by the `FetchVariantAnnotationByGenomicLocationPOST` function. The function used to return 3 values but now returns only 1 value after we regenerated the Genome Nexus API with version 6.2.1 (https://github.com/averyniceday/go-mpath-proto/pull/3).
I also ran `go mod tidy` to clean up the go.mod and go.sum files.
